### PR TITLE
chore: Change to onEvent

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -48,60 +48,46 @@ export const setupPlugin: PubSubPlugin['setupPlugin'] = async (meta) => {
     }
 }
 
-export async function exportEvents(events: PluginEvent[], { global, config }: PluginMeta<PubSubPlugin>) {
+export async function onEvent(fullEvent: PluginEvent, { global, config }: PluginMeta<PubSubPlugin>) {
     if (!global.pubSubClient) {
         throw new Error('No PubSub client initialized!')
     }
     try {
-        const messages = events.map((fullEvent) => {
-            const { event, properties, $set, $set_once, distinct_id, team_id, site_url, now, sent_at, uuid, ...rest } =
-                fullEvent
-            const ip = properties?.['$ip'] || fullEvent.ip
-            const timestamp = fullEvent.timestamp || properties?.timestamp || now || sent_at
-            let ingestedProperties = properties
-            let elements = []
+        const { event, properties, $set, $set_once, distinct_id, team_id, site_url, now, sent_at, uuid, ...rest } =
+            fullEvent
+        const ip = properties?.['$ip'] || fullEvent.ip
+        const timestamp = fullEvent.timestamp || properties?.timestamp || now || sent_at
+        let ingestedProperties = properties
+        let elements = []
 
-            // only move prop to elements for the $autocapture action
-            if (event === '$autocapture' && properties?.['$elements']) {
-                const { $elements, ...props } = properties
-                ingestedProperties = props
-                elements = $elements
-            }
+        // only move prop to elements for the $autocapture action
+        if (event === '$autocapture' && properties?.['$elements']) {
+            const { $elements, ...props } = properties
+            ingestedProperties = props
+            elements = $elements
+        }
 
-            const message = {
-                event,
-                distinct_id,
-                team_id,
-                ip,
-                site_url,
-                timestamp,
-                uuid: uuid!,
-                properties: ingestedProperties || {},
-                elements: elements || [],
-                people_set: $set || {},
-                people_set_once: $set_once || {},
-            }
-            return Buffer.from(JSON.stringify(message))
+        const message = {
+            event,
+            distinct_id,
+            team_id,
+            ip,
+            site_url,
+            timestamp,
+            uuid: uuid!,
+            properties: ingestedProperties || {},
+            elements: elements || [],
+            people_set: $set || {},
+            people_set_once: $set_once || {},
+        }
+        const dataBuf = Buffer.from(JSON.stringify(message))
+
+        await global.pubSubTopic.publish(dataBuf).then((messageId) => {
+            return messageId
         })
-
-        const start = Date.now()
-        await Promise.all(
-            messages.map((dataBuf) =>
-                global.pubSubTopic.publish(dataBuf).then((messageId) => {
-                    return messageId
-                })
-            )
-        )
-        const end = Date.now() - start
-
-        console.log(
-            `Published ${events.length} ${events.length > 1 ? 'events' : 'event'} to ${config.topicId}. Took ${
-                end / 1000
-            } seconds.`
-        )
     } catch (error) {
         console.error(
-            `Error publishing ${events.length} ${events.length > 1 ? 'events' : 'event'} to ${config.topicId}: `,
+            `Error publishing ${event.uuid} to ${config.topicId}: `,
             error
         )
         throw new RetryError(`Error publishing to Pub/Sub! ${JSON.stringify(error.errors)}`)


### PR DESCRIPTION
We're deprecating exportEvents function in favor of batch exports or onEvent

Total usage in EU is very low
<img width="454" alt="Screenshot 2023-11-09 at 16 22 39" src="https://github.com/PostHog/pubsub-plugin/assets/890921/a6f8fc3a-9cf4-46c8-bf11-2591cbc86f1d">

In the US it's higher (33+15M per 30 days), but most events are sent alone or <10 together.
http://metabase-prod-us/question/357-pub-sub-events-sent-together-based-on-log
<img width="877" alt="Screenshot 2023-11-09 at 16 18 08" src="https://github.com/PostHog/pubsub-plugin/assets/890921/f08cab0e-c138-4cba-9699-792376385d87">

