### PR TITLE
Fix ReferenceError: event is not defined

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -87,7 +87,7 @@ export async function onEvent(fullEvent: PluginEvent, { global, config }: Plugin
         })
     } catch (error) {
         console.error(
-            `Error publishing ${event.uuid} to ${config.topicId}: `,
+            `Error publishing ${fullEvent.uuid} to ${config.topicId}: `,
             error
         )
         throw new RetryError(`Error publishing to Pub/Sub! ${JSON.stringify(error.errors)}`)


### PR DESCRIPTION
Error reporting on this app is broken and reports `ReferenceError: event is not defined` instead of the downstream error. This should fix the logging and allow to surface the downstream error properly.